### PR TITLE
Update SSH instructions

### DIFF
--- a/docs/access.md
+++ b/docs/access.md
@@ -16,9 +16,30 @@ You will be given a username and a one time password (OTP). **Note: You must log
 
 ## Shell Access
 
+### SSH Terminal Program
+
+**Windows** 
+
+There are a number of popular options to get SSH on Windows.
+
+* Windows has an OpenSSH client that is disabled by default, but can be enabled using [this guide](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui). You only need the client, not the server.
+* [PuTTY](https://www.putty.org/) is a classic cross-platofrm solution. Provides users with a ssh terminal login window capable of GUI support. [Getting Started Guide](https://the.earth.li/~sgtatham/putty/0.74/htmldoc/Chapter2.html#gs)
+* Windows Subsystem for Linux [Guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10). Brings a linux terminal program to the Windows OS.
+* Download and install [GIT](https://git-scm.com/). The included git bash terminal program has a ssh command.
+
+**Mac or Linux**
+
+Your operating system includes this by default, yay! Launch terminal and issue `which ssh` to see the location of the ssh program binary file.
+
+Then enter the ssh connect commands below.
+
+*More info about SSH available on the [OpenSSH homepage](https://openssh.com).*
+
+### Connecting with Terminal Program
+
 Users can directly connect to the management nodes and open a command line interface.
 
-Connect with **ssh** to management node 2, 3, or 4.
+Open a terminal, then use one of the commands below to connect with **ssh** to management node 2, 3, or 4.
 
 ```bash
 # connect to mgmt2
@@ -30,24 +51,6 @@ $ ssh username@dh-mgmt3.hpc.msoe.edu
 # connect to mgmt4
 $ ssh username@dh-mgmt4.hpc.msoe.edu
 ```
-
-### SSH Terminal Program
-
-**Windows** 
-
-The Windows Operating System does not include ssh by default. There are a number of popular options.
-
-* [PuTTY](https://www.putty.org/) is a classic cross-platofrm solution. Provides users with a ssh terminal login window capable of GUI support. [Getting Started Guide](https://the.earth.li/~sgtatham/putty/0.74/htmldoc/Chapter2.html#gs)
-* Windows Subsystem for Linux [Guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10). Brings a linux terminal program to the Windows OS.
-* Download and install [GIT](https://git-scm.com/). The included git bash terminal program has a ssh command.
-
-**Mac or Linux**
-
-Your operating system includes this by default, yay! Launch terminal and issue `which ssh` to see the location of the ssh program binary file.
-
-Then enter the ssh connect commands above.
-
-*More info about SSH available on the [OpenSSH homepage](https://openssh.com).*
 
 ### Connecting with PuTTY on Windows
 


### PR DESCRIPTION
Windows does have its own SSH program, it is just not enabled by default. I added a guide from Microsoft that shows how to enable it. I also moved the instructions for connecting with SSH to below the SSH installation instructions. You can not use SSH without installing it, so it does not make sense to have it in the order it was before.